### PR TITLE
remove solid_blocks attrib; add get_solid_blocks()

### DIFF
--- a/demo/demo.py
+++ b/demo/demo.py
@@ -115,7 +115,7 @@ while not done:
                             animated_sprite.image.get_size())
 
     tilemap_on_players_index = layer_tilemaps[ANIMATED_SPRITE_Z_INDEX]
-    solid_blocks_on_players_index = tilemap_on_players_index.solid_blocks
+    solid_blocks_on_players_index = tilemap_on_players_index.get_solid_blocks()
 
     if rect.collidelist(solid_blocks_on_players_index) != -1:
         print("colliding!")

--- a/sappho/tilemap.py
+++ b/sappho/tilemap.py
@@ -169,7 +169,7 @@ class TileMap(object):
 
     """
 
-    def __init__(self, tilesheet, tiles, solid_blocks=[]):
+    def __init__(self, tilesheet, tiles):
         """
 
         Arguments:
@@ -180,7 +180,31 @@ class TileMap(object):
 
         self.tilesheet = tilesheet
         self.tiles = tiles
-        self.solid_blocks = solid_blocks
+
+    def get_solid_blocks(self):
+        """Return the Pygame rect of all
+        the tiles which have the solid_block
+        attribute.
+
+        Returns:
+            list(pygame.Rect): --
+
+        """
+
+        solid_blocks = []
+
+        for y, row_of_tiles in enumerate(self.tiles):
+
+            for x, tile in enumerate(row_of_tiles):
+                
+                if tile.solid_block:
+                    left_top = (x * self.tilesheet.tile_size[0],
+                                y * self.tilesheet.tile_size[1])
+                    block = pygame.rect.Rect(left_top,
+                                             self.tilesheet.tile_size)
+                    solid_blocks.append(block)
+
+        return solid_blocks
 
     def to_surface(self):
         """Blit the tiles to a surface and return it!
@@ -223,7 +247,6 @@ class TileMap(object):
         """
 
         sheet = []
-        solid_blocks = []
 
         for y, line in enumerate(csv_string.split('\n')):
             row = []
@@ -236,20 +259,11 @@ class TileMap(object):
 
                 tile_id = int(tile_id_string) - firstgid
                 tile = tilesheet.tiles[tile_id]
-
-                if tile.solid_block:
-                    left_top = (x * tilesheet.tile_size[0],
-                                y * tilesheet.tile_size[1])
-                    block = pygame.rect.Rect(left_top, tilesheet.tile_size)
-                    solid_blocks.append(block)
-
-                # create absolute rect and add to group
-
                 row.append(tile)
 
             sheet.append(row)
 
-        return cls(tilesheet, sheet, solid_blocks)
+        return cls(tilesheet, sheet)
 
 
 def index_to_coord(width, i):

--- a/tests/test_tilemap.py
+++ b/tests/test_tilemap.py
@@ -80,9 +80,10 @@ class TestTilemap(object):
         # The tile ID 0 is set as a solid block, and this is at (0, 0) to (1, 1)
         # in the tilemap. Here, we check that a solid block has been correctly
         # entered into the tilemap.
-        assert(len(tilemap.solid_blocks) == 1)
-        assert(tilemap.solid_blocks[0].topleft == (0, 0))
-        assert(tilemap.solid_blocks[0].bottomright == (1, 1))
+        solid_blocks = tilemap.get_solid_blocks()
+        assert(len(solid_blocks) == 1)
+        assert(solid_blocks[0].topleft == (0, 0))
+        assert(solid_blocks[0].bottomright == (1, 1))
 
     def test_from_tmx(self):
         testpath = os.path.realpath(__file__)
@@ -95,9 +96,10 @@ class TestTilemap(object):
         tilemap = tilemaps[0]
 
         # Same as the above test, check for the solid block
-        assert(len(tilemap.solid_blocks) == 1)
-        assert(tilemap.solid_blocks[0].topleft == (0, 0))
-        assert(tilemap.solid_blocks[0].bottomright == (1, 1))
+        solid_blocks = tilemap.get_solid_blocks()
+        assert(len(solid_blocks) == 1)
+        assert(solid_blocks[0].topleft == (0, 0))
+        assert(solid_blocks[0].bottomright == (1, 1))
 
     def test_render(self):
         csv = textwrap.dedent(self.TILEMAP_CSV).strip()


### PR DESCRIPTION
Remove `solid_blocks` as a constructor argument
and attribute of `TileMap`.

Add `get_solid_blocks()` to get the rectangles,
with proper position, for each tile in tilemap.

Change various endpoints to reflect these changes.